### PR TITLE
Added x-example vendor extension property

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -151,6 +151,10 @@ extensions:
     name: "Apiary"
     source_url: "https://help.apiary.io/api_101/swagger-extensions/"
     gist_url: "https://gist.github.com/netmilk/e61bd109dca737f77cf2.js"
+  - title: "x-example"
+    name: "Apiary"
+    source_url: "https://help.apiary.io/api_101/swagger-extensions/"
+    gist_url: "https://gist.github.com/honzajavorek/12b536f8ba0c9977f5e2605aecb4607b.js"
 
 # sponsors
 sponsors_margin_top: 15


### PR DESCRIPTION
I'm just about to release a new version of Dredd (https://github.com/apiaryio/dredd/pull/581) which supports x-example vendor extension property for specifying example values for request parameters. This allows Dredd to know which values to use when performing tests.

The linked page doesn't contain docs for `x-example` yet, but I have internal PR with it ready, so it will be there very soon.